### PR TITLE
update authlogic_radius to work with existing validators

### DIFF
--- a/authlogic_radius.gemspec
+++ b/authlogic_radius.gemspec
@@ -6,14 +6,14 @@
 
 Gem::Specification.new do |s|
   s.name = "authlogic_radius"
-  s.version = "0.2.0"
+  s.version = "0.3.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
-  s.authors = ["Brad Langhorst"]
-  s.date = "2014-07-15"
+  s.authors = ["Brad Langhorst", "Mike Lyons"]
+  s.date = "2023-08-3"
   s.description = "This is a simple gem to allow authentication against a RADIUS server.\n"
-  s.email = "langhorst@neb.com"
+  s.email = ["langhorst@neb.com", "mike@tahoelabs.io"]
   s.extra_rdoc_files = [
     "LICENSE",
     "README.rdoc"

--- a/authlogic_radius.gemspec
+++ b/authlogic_radius.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Brad Langhorst", "Mike Lyons"]
-  s.date = "2023-08-3"
+  s.date = "2023-08-03"
   s.description = "This is a simple gem to allow authentication against a RADIUS server.\n"
   s.email = ["langhorst@neb.com", "mike@tahoelabs.io"]
   s.extra_rdoc_files = [

--- a/lib/authlogic_radius/acts_as_authentic.rb
+++ b/lib/authlogic_radius/acts_as_authentic.rb
@@ -25,17 +25,6 @@ module AuthlogicRadius
       def self.included(klass)
         klass.class_eval do
           attr_accessor :radius_password
-          
-          if validate_radius_login
-            validates_uniqueness_of :radius_login, :scope => validations_scope, :if => :using_radius?
-          end
-          validates_length_of_password_field_options validates_length_of_password_field_options.merge(:unless => :using_radius?)
-          validates_confirmation_of_password_field_options validates_confirmation_of_password_field_options.merge(:unless => :using_radius?)
-          validates_length_of_password_confirmation_field_options validates_length_of_password_confirmation_field_options.merge(:unless => :using_radius?)
-          validates_length_of_login_field_options validates_length_of_login_field_options.merge(:unless => :using_radius?)
-          validates_uniqueness_of_login_field_options validates_uniqueness_of_login_field_options.merge(:unless => :using_radius?)
-          validates_format_of_login_field_options validates_format_of_login_field_options.merge(:unless => :using_radius?)
-
         end
       end
 


### PR DESCRIPTION
the methods that are removed in this gem are now used like so, instead of these custom methods in authlogic:
```
class User < ApplicationRecord
  acts_as_authentic

  # Validate email, login, and password as you see fit.
  #
  # Authlogic < 5 added these validation for you, making them a little awkward
  # to change. In 4.4.0, those automatic validations were deprecated. See
  # https://github.com/binarylogic/authlogic/blob/master/doc/use_normal_rails_validation.md
  validates :email,
    format: {
      with: /@/,
      message: "should look like an email address."
    },
    length: { maximum: 100 },
    uniqueness: {
      case_sensitive: false,
      if: :will_save_change_to_email?
    }

  validates :login,
    format: {
      with: /\A[a-z0-9]+\z/,
      message: "should use only letters and numbers."
    },
    length: { within: 3..100 },
    uniqueness: {
      case_sensitive: false,
      if: :will_save_change_to_login?
    }

  validates :password,
    confirmation: { if: :require_password? },
    length: {
      minimum: 8,
      if: :require_password?
    }
  validates :password_confirmation,
    length: {
      minimum: 8,
      if: :require_password?
  }
end
```

Also ups the version number of the gem. 